### PR TITLE
fix: nginx and database configuration and update Docker images

### DIFF
--- a/backend/minersentinel/settings.py
+++ b/backend/minersentinel/settings.py
@@ -71,8 +71,8 @@ DATABASES = {
         'NAME': config('POSTGRES_DB', default='minersentinel'),
         'USER': config('POSTGRES_USER', default='minersentinel'),
         'PASSWORD': config('POSTGRES_PASSWORD', default='changeme'),
-        'HOST': config('DB_HOST', default='postgres'),
-        'PORT': config('DB_PORT', default='5432'),
+        'HOST': config('POSTGRES_HOST', default='postgres'),
+        'PORT': config('POSTGRES_PORT', default='5432'),
     }
 }
 

--- a/build_and_push_for_umbrel.sh
+++ b/build_and_push_for_umbrel.sh
@@ -7,7 +7,7 @@ set -e
 
 # Configuration
 DOCKER_HUB_USER="dcbert"
-VERSION="${VERSION:-v1.0.0}"
+VERSION="${VERSION:-v1.0.1}"
 IMAGES=("backend" "frontend" "data-service")
 
 # Colors for output

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,7 +13,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
     }
     location /admin {
@@ -21,7 +21,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
     }
     location /static {
@@ -29,7 +29,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
     }
 }

--- a/umbrel/docker-compose.yml
+++ b/umbrel/docker-compose.yml
@@ -6,12 +6,13 @@ services:
       APP_HOST: miner-sentinel_frontend_1
       APP_PORT: 80
 
-  postgres:
-    image: postgres:17-alpine@sha256:d4b770d9b26b92b5755a7dc0da0b1b8df9ffd18a71a7fdc047d8a2154e3fad43
+  db:
+    image: postgres:17.7@sha256:bac8128cd62a35471a1e97966861aa2ac88c8d2f408767a425ae70695a607c99
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ${APP_DATA_DIR}/db/postgres:/var/lib/postgresql/data
+      - ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: minersentinel
       POSTGRES_PASSWORD: minersentinel
@@ -23,15 +24,15 @@ services:
       retries: 5
 
   backend:
-    image: dcbert/minersentinel-backend:latest@sha256:377216af9792d23fdc374d8f7d239db77ab6255fee5f4f6dc5686762d591ce3e
+    image: dcbert/minersentinel-backend:latest@sha256:d5f46aa215f181637e51d529da8a440c7f73ebdf2cf2cee763ca8afc58e20000
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
-      - postgres
+      - db
     environment:
       # Database configuration
-      POSTGRES_HOST: miner-sentinel_postgres_1
-      POSTGRES_PORT: 5432
+      DB_HOST: miner-sentinel_postgres_1
+      DB_PORT: 5432
       POSTGRES_DB: minersentinel
       POSTGRES_USER: minersentinel
       POSTGRES_PASSWORD: minersentinel
@@ -56,7 +57,7 @@ services:
       "
 
   frontend:
-    image: dcbert/minersentinel-frontend:latest@sha256:ea16ddcc01dca2c361a693c9aec50caed257b78f7dc6f3de12067b41f731e62d
+    image: dcbert/minersentinel-frontend:latest@sha256:b7ee9a7cc8bf797b45baa7ce56e4bd8a4635ffd085f80aa7ce4ac8832211d62d
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -65,11 +66,11 @@ services:
       VITE_API_URL: "http://${DEVICE_DOMAIN_NAME}:3080"
 
   data-service:
-    image: dcbert/minersentinel-data-service:latest@sha256:5dde08576f404fd3c5bf039cb15b33be04718617e2c9e34409abc6f143940b7a
+    image: dcbert/minersentinel-data-service:latest@sha256:f87bbc9f4e755454718a3eb8190502c7cc65e7d7fb8b40158cf487c26a773f53
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
-      - postgres
+      - db
       - backend
     environment:
       # Database configuration

--- a/umbrel/docker-compose.yml.bak
+++ b/umbrel/docker-compose.yml.bak
@@ -6,12 +6,13 @@ services:
       APP_HOST: miner-sentinel_frontend_1
       APP_PORT: 80
 
-  postgres:
-    image: postgres:17-alpine@sha256:d4b770d9b26b92b5755a7dc0da0b1b8df9ffd18a71a7fdc047d8a2154e3fad43
+  db:
+    image: postgres:17.7@sha256:bac8128cd62a35471a1e97966861aa2ac88c8d2f408767a425ae70695a607c99
+    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ${APP_DATA_DIR}/db/postgres:/var/lib/postgresql/data
+      - ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: minersentinel
       POSTGRES_PASSWORD: minersentinel
@@ -23,15 +24,15 @@ services:
       retries: 5
 
   backend:
-    image: dcbert/minersentinel-backend:1.0.0@sha256:0a545cb0dbbaa7772560963ebb4cff63ad3919ac1ba8750aa5850388a7b1788c
+    image: dcbert/minersentinel-backend:latest@sha256:24d1ab8df5bdc3326ad81c4343e472e34a113d4c31330342f588321acfe54bff
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
-      - postgres
+      - db
     environment:
       # Database configuration
-      POSTGRES_HOST: miner-sentinel_postgres_1
-      POSTGRES_PORT: 5432
+      DB_HOST: miner-sentinel_postgres_1
+      DB_PORT: 5432
       POSTGRES_DB: minersentinel
       POSTGRES_USER: minersentinel
       POSTGRES_PASSWORD: minersentinel
@@ -56,7 +57,7 @@ services:
       "
 
   frontend:
-    image: dcbert/minersentinel-frontend:1.0.0@sha256:2144eb49160f841f0d4191a59942f7b18a1a3e89058332c2e6e807886158652a
+    image: dcbert/minersentinel-frontend:latest@sha256:aec17969a4b99362554f3265e58442e216c66e963e87721b55182e242a2d0c16
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
@@ -65,11 +66,11 @@ services:
       VITE_API_URL: "http://${DEVICE_DOMAIN_NAME}:3080"
 
   data-service:
-    image: dcbert/minersentinel-data-service:1.0.0@sha256:aee26fe4db5f5d6d403154e73f609b454eccc54e7c78f21998dfda7ff4f5f589
+    image: dcbert/minersentinel-data-service:latest@sha256:b1a93c2bb54c6cb2092317db52fa852b59d3bcc34c226af426e0dff9aa01cd9d
     restart: on-failure
     stop_grace_period: 1m
     depends_on:
-      - postgres
+      - db
       - backend
     environment:
       # Database configuration


### PR DESCRIPTION
This pull request updates the configuration for the database service and Docker images, aiming to standardize environment variable usage, improve naming consistency, and update service images. The most significant changes involve renaming the database service from `postgres` to `db`, aligning environment variable names across the stack, updating Docker image tags and digests, and adjusting Nginx and Docker Compose configurations for improved compatibility.

**Database service and environment variable standardization:**

* Renamed the database service from `postgres` to `db` in both `umbrel/docker-compose.yml` and its backup, updated the image to `postgres:17.7`, set an explicit user, and changed the data volume path for consistency. [[1]](diffhunk://#diff-d8dc7e3176a8634388ee5ef5516793c7e89f8a5f46c297314b378f7700c04ed1L9-R15) [[2]](diffhunk://#diff-86de55919913e7348403da6cfc9290d8ecb84e06e17296249ad4d07721ae5cc1L9-R15)
* Standardized database environment variable names in `backend/minersentinel/settings.py` to use `POSTGRES_HOST` and `POSTGRES_PORT` instead of `DB_HOST` and `DB_PORT`.
* Updated the backend and data-service container environment variables in Docker Compose files to use `DB_HOST` and `DB_PORT` instead of `POSTGRES_HOST` and `POSTGRES_PORT`, aligning with the new service name and environment variable usage. [[1]](diffhunk://#diff-d8dc7e3176a8634388ee5ef5516793c7e89f8a5f46c297314b378f7700c04ed1L26-R35) [[2]](diffhunk://#diff-86de55919913e7348403da6cfc9290d8ecb84e06e17296249ad4d07721ae5cc1L26-R35)

**Docker image updates:**

* Updated the Docker image tags and digests for `backend`, `frontend`, and `data-service` services in both Docker Compose files to use the latest versions. [[1]](diffhunk://#diff-d8dc7e3176a8634388ee5ef5516793c7e89f8a5f46c297314b378f7700c04ed1L26-R35) [[2]](diffhunk://#diff-d8dc7e3176a8634388ee5ef5516793c7e89f8a5f46c297314b378f7700c04ed1L59-R60) [[3]](diffhunk://#diff-d8dc7e3176a8634388ee5ef5516793c7e89f8a5f46c297314b378f7700c04ed1L68-R73) [[4]](diffhunk://#diff-86de55919913e7348403da6cfc9290d8ecb84e06e17296249ad4d07721ae5cc1L26-R35) [[5]](diffhunk://#diff-86de55919913e7348403da6cfc9290d8ecb84e06e17296249ad4d07721ae5cc1L59-R60) [[6]](diffhunk://#diff-86de55919913e7348403da6cfc9290d8ecb84e06e17296249ad4d07721ae5cc1L68-R73)
* Bumped the default version in `build_and_push_for_umbrel.sh` from `v1.0.0` to `v1.0.1`.

**Nginx configuration improvement:**

* Updated the Nginx configuration in `frontend/nginx.conf` to use `$http_host` instead of `$host` for the `Host` header in proxy settings, which can improve compatibility with proxied requests.